### PR TITLE
docs: 更新启动命令中的 config 路径

### DIFF
--- a/src/app/(cn)/development/deploys/deploy-edge/page.mdx
+++ b/src/app/(cn)/development/deploys/deploy-edge/page.mdx
@@ -127,7 +127,7 @@ cp ./unilabos/config/config.py ./unilabos/config/local_config.py
 # python ./unilabos/app/main.py 可被替换为 unilab
 python ./unilabos/app/main.py \
     -g ./test/experiments/mock_reactor.json \
-    --config ./config/local_config.py \
+    --config ./unilabos/config/local_config.py \
     --upload_registry \
     --disable_browser
 ```


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

文档：
- 调整 deploy-edge 页面中的 `--config` 路径，以引用 `unilabos/config/local_config.py`，而不是 `config/local_config.py`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Adjust the --config path in the deploy-edge page to reference unilabos/config/local_config.py instead of config/local_config.py

</details>